### PR TITLE
Update arxiv

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ _**surfinBH**_ provides _**sur**rogate **fin**al **B**lack_ _**H**ole_
 properties for mergers of binary black holes (BBH).
 
 These fits are described in the following papers: <br/>
-[1] Vijay Varma, Davide Gerosa, François Hébert, Leo C. Stein and Hao Zhang,
+[1] Vijay Varma, Davide Gerosa, Leo C. Stein, François Hébert and Hao Zhang,
 [arxiv:1809.09125](https://arxiv.org/abs/1809.09125).
 
 If you find this package useful in your work, please cite reference [1] and,

--- a/examples/example_3dq8.ipynb
+++ b/examples/example_3dq8.ipynb
@@ -11,16 +11,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/vijay/opt/softs/anaconda2/lib/python2.7/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
-      "  from ._conv import register_converters as _register_converters\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import surfinBH"
    ]
@@ -79,11 +70,12 @@
       "Help on Fit3dq8 in module surfinBH._fit_evaluators.fit_3dq8 object:\n",
       "\n",
       "class Fit3dq8(surfinBH.surfinBH.SurFinBH)\n",
-      " |  A class for the surfinBH3dq8 model presented in Varma et al., 2018,\n",
-      " |  in prep. This model predicts the final mass mf, final spin chif and final\n",
-      " |  kick velocity vf, for the remnants of nonprecessing binary black hole\n",
-      " |  systems. The fits are done using Gaussian Process Regression (GPR) and\n",
-      " |  also provide an error estimate along with the fit value.\n",
+      " |  A class for the surfinBH3dq8 model presented in Varma et al.,\n",
+      " |  arxiv:1809.09125. This model predicts the final mass mf, final\n",
+      " |  spin chif and final kick velocity vf, for the remnants of nonprecessing\n",
+      " |  binary black hole systems. The fits are done using Gaussian Process\n",
+      " |  Regression (GPR) and also provide an error estimate along with the fit\n",
+      " |  value.\n",
       " |  \n",
       " |  This model has been trained in the parameter space:\n",
       " |      q <= 8, |chiAz| <= 0.8, |chiBz| <= 0.8\n",

--- a/examples/example_7dq2.ipynb
+++ b/examples/example_7dq2.ipynb
@@ -11,16 +11,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/vijay/opt/softs/anaconda2/lib/python2.7/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
-      "  from ._conv import register_converters as _register_converters\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import surfinBH"
    ]
@@ -79,11 +70,12 @@
       "Help on Fit7dq2 in module surfinBH._fit_evaluators.fit_7dq2 object:\n",
       "\n",
       "class Fit7dq2(surfinBH.surfinBH.SurFinBH)\n",
-      " |  A class for the surfinBH7dq2 model presented in Varma et al., 2018,\n",
-      " |  in prep. This model predicts the final mass mf, final spin vector chif and\n",
-      " |  final kick velocity vector vf, for the remnants of precessing binary\n",
-      " |  black hole systems.  The fits are done using Gaussian Process Regression\n",
-      " |  (GPR) and also provide an error estimate along with the fit value.\n",
+      " |  A class for the surfinBH7dq2 model presented in Varma et al.,\n",
+      " |  arxiv:1809.09125. This model predicts the final mass mf, final spin vector\n",
+      " |  chif and final kick velocity vector vf, for the remnants of precessing\n",
+      " |  binary black hole systems.  The fits are done using Gaussian Process\n",
+      " |  Regression (GPR) and also provide an error estimate along with the fit\n",
+      " |  value.\n",
       " |  \n",
       " |  This model has been trained in the parameter space:\n",
       " |      q <= 2, |chiA| <= 0.8, |chiB| <= 0.8\n",
@@ -304,7 +296,7 @@
     "# Note: The component spins, remnant spin and kick are all\n",
     "# assumed to be in the inertial frame defined at orbital frequency=omega0.\n",
     "\n",
-    "# Initial dimensionless orbital frequency (in units of 1/M)\n",
+    "# Initial dimensionless orbital frequency (in units of rad/M)\n",
     "omega0 = 7e-3\n",
     "  \n",
     "# remnant mass and 1-sigma error estimate\n",

--- a/surfinBH/_fit_evaluators/fit_3dq8.py
+++ b/surfinBH/_fit_evaluators/fit_3dq8.py
@@ -4,11 +4,12 @@ import warnings
 
 #=============================================================================
 class Fit3dq8(surfinBH.SurFinBH):
-    """ A class for the surfinBH3dq8 model presented in Varma et al., 2018,
-    in prep. This model predicts the final mass mf, final spin chif and final
-    kick velocity vf, for the remnants of nonprecessing binary black hole
-    systems. The fits are done using Gaussian Process Regression (GPR) and
-    also provide an error estimate along with the fit value.
+    """ A class for the surfinBH3dq8 model presented in Varma et al.,
+    arxiv:1809.09125. This model predicts the final mass mf, final
+    spin chif and final kick velocity vf, for the remnants of nonprecessing
+    binary black hole systems. The fits are done using Gaussian Process
+    Regression (GPR) and also provide an error estimate along with the fit
+    value.
 
     This model has been trained in the parameter space:
         q <= 8, |chiAz| <= 0.8, |chiBz| <= 0.8

--- a/surfinBH/_fit_evaluators/fit_7dq2.py
+++ b/surfinBH/_fit_evaluators/fit_7dq2.py
@@ -6,11 +6,12 @@ import warnings
 
 #=============================================================================
 class Fit7dq2(surfinBH.SurFinBH):
-    """ A class for the surfinBH7dq2 model presented in Varma et al., 2018,
-    in prep. This model predicts the final mass mf, final spin vector chif and
-    final kick velocity vector vf, for the remnants of precessing binary
-    black hole systems.  The fits are done using Gaussian Process Regression
-    (GPR) and also provide an error estimate along with the fit value.
+    """ A class for the surfinBH7dq2 model presented in Varma et al.,
+    arxiv:1809.09125. This model predicts the final mass mf, final spin vector
+    chif and final kick velocity vector vf, for the remnants of precessing
+    binary black hole systems.  The fits are done using Gaussian Process
+    Regression (GPR) and also provide an error estimate along with the fit
+    value.
 
     This model has been trained in the parameter space:
         q <= 2, |chiA| <= 0.8, |chiB| <= 0.8


### PR DESCRIPTION
This fixes issue #2. 
Note, the paper for 3dq8 is also the surfinBH paper, the new surrogate paper is only for the waveform surrogate.